### PR TITLE
Run html2react include subfolder.

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -30,7 +30,7 @@ gulp.task('browserSync', function() {
 
 
 gulp.task('react', function() {
-	return gulp.src('app/javascripts/templates/*.html')
+	return gulp.src('app/javascripts/templates/**/*.html')
 		.pipe(html2react())
 		.pipe(gulp.dest('temp/javascripts/templates'));
 });


### PR DESCRIPTION
The subfolder wasn't compile to `temp/templates` folder.

![default](https://cloud.githubusercontent.com/assets/5094008/4837913/1173f6cc-5fe0-11e4-94a7-3eb0d5352d82.PNG)
